### PR TITLE
fix: update the console error for parseError

### DIFF
--- a/src/plugins/react-intl.js
+++ b/src/plugins/react-intl.js
@@ -88,8 +88,7 @@ export default function () {
 
                     throw valuePath.buildCodeFrameError(
                         '[React Intl] Message failed to parse. ' +
-                        'See: http://formatjs.io/guides/message-syntax/',
-                        parseError
+                        'See: http://formatjs.io/guides/message-syntax/'
                     );
                 }
             } else {


### PR DESCRIPTION
Currently, the babel transformer throws an error:

```
Module build failed: TypeError: C:/..../App.js: Error is not a constructor
```

which isn't helpful, and actually an error in itself. This commit fixes that.